### PR TITLE
Potential fix for code scanning alert no. 14: Clear-text logging of sensitive information

### DIFF
--- a/cmd/clef/main.go
+++ b/cmd/clef/main.go
@@ -1085,6 +1085,13 @@ func GenDoc(ctx *cli.Context) error {
 		}
 		output []string
 		add    = func(name, desc string, v interface{}) {
+			// Redact sensitive fields if the object is of a sensitive type
+			switch obj := v.(type) {
+			case *core.UserInputRequest:
+				obj.Prompt = "REDACTED"
+			case *core.UserInputResponse:
+				obj.Text = "REDACTED"
+			}
 			if data, err := json.MarshalIndent(v, "", "  "); err == nil {
 				output = append(output, fmt.Sprintf("### %s\n\n%s\n\nExample:\n```json\n%s\n```", name, desc, data))
 			} else {


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56-cb-id/bsc/security/code-scanning/14](https://github.com/roseteromeo56-cb-id/bsc/security/code-scanning/14)

To fix the issue, we need to ensure that sensitive data, such as user input marked as a password, is not logged or printed in clear text. This can be achieved by modifying the `add` function to exclude or obfuscate sensitive fields before appending the serialized JSON to the `output` slice. Specifically, we can check if the object being serialized is of type `core.UserInputRequest` or `core.UserInputResponse` and redact sensitive fields (e.g., replace the `Text` field with a placeholder like `"REDACTED"`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
