### PR TITLE
Potential fix for code scanning alert no. 13: Incorrect conversion between integer types

### DIFF
--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -451,6 +451,10 @@ func inspectTrie(ctx *cli.Context) error {
 			if err != nil {
 				return fmt.Errorf("failed to parse jobnum, Args[1]: %v, err: %v", ctx.Args().Get(1), err)
 			}
+			// Ensure jobnum is within the bounds of int64
+			if jobnum > math.MaxInt64 {
+				return fmt.Errorf("jobnum exceeds maximum value for int64: %v", jobnum)
+			}
 			topN = 10
 		} else {
 			var err error


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56-cb-id/bsc/security/code-scanning/13](https://github.com/roseteromeo56-cb-id/bsc/security/code-scanning/13)

To fix the issue, we need to ensure that the value of `jobNum` is within the valid range of `int64` before performing the conversion. This can be achieved by adding an upper bound check for `jobNum` against `math.MaxInt64`. If the value exceeds this limit, the program should handle it gracefully, such as by returning an error or using a default value.

The changes will be made in two places:
1. In `cmd/geth/dbcmd.go`, where `jobNum` is parsed from user input, we will add a bounds check after parsing.
2. In `trie/inspect_trie.go`, we will ensure that the `NewInspector` function does not receive an out-of-bounds value for `jobNum`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
