### PR TITLE
Potential fix for code scanning alert no. 8: Incorrect conversion between integer types

### DIFF
--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"math"
 	"sort"
 	"strconv"
 	"strings"
@@ -58,8 +59,14 @@ func (b *Long) UnmarshalGraphQL(input interface{}) error {
 		if strings.HasPrefix(input, "0x") {
 			// apply leniency and support hex representations of longs.
 			value, err := hexutil.DecodeUint64(input)
+			if err != nil {
+				return err
+			}
+			if value > math.MaxInt64 {
+				return fmt.Errorf("value %d exceeds int64 range", value)
+			}
 			*b = Long(value)
-			return err
+			return nil
 		} else {
 			value, err := strconv.ParseInt(input, 10, 64)
 			*b = Long(value)


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56-cb-id/bsc/security/code-scanning/8](https://github.com/roseteromeo56-cb-id/bsc/security/code-scanning/8)

To fix the issue, we need to add bounds checking before converting the `uint64` value to `int64`. Specifically:
1. Check if the `uint64` value exceeds the maximum value of `int64` (`math.MaxInt64`).
2. If the value is within bounds, proceed with the conversion. Otherwise, return an error indicating that the value is out of range.

This fix ensures that the conversion is safe and prevents unexpected behavior due to out-of-range values.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
