### PR TITLE
Potential fix for code scanning alert no. 7: Incorrect conversion between integer types

### DIFF
--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -467,6 +467,10 @@ func inspectTrie(ctx *cli.Context) error {
 			if err != nil {
 				return fmt.Errorf("failed to parse topn, Args[1]: %v, err: %v", ctx.Args().Get(1), err)
 			}
+			// Ensure topN is within the bounds of int
+			if topN > math.MaxInt32 {
+				return fmt.Errorf("topN exceeds maximum value for int: %v", topN)
+			}
 		}
 
 		if blockNumber != math.MaxUint64 {


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56-cb-id/bsc/security/code-scanning/7](https://github.com/roseteromeo56-cb-id/bsc/security/code-scanning/7)

To fix the issue, we need to add an upper bound check for `topN` before converting it to `int`. The maximum value of `int` can be determined using `math.MaxInt32` or `math.MaxInt64`, depending on the platform. Since `topN` is parsed as a `uint64`, we should ensure that its value does not exceed the maximum value of `int`. If the value is out of bounds, we can return an error or use a default value.

Changes to be made:
1. Add a bounds check for `topN` after parsing it on line 466.
2. Ensure that the conversion to `int` on line 502 is safe and does not lead to unexpected behavior.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
