### PR TITLE
Potential fix for code scanning alert no. 18: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,9 @@
 name: Release
 
+permissions:
+  contents: read
+
 on:
-  push:
     # Publish `v1.2.3` tags as releases.
     tags:
       - v*
@@ -112,6 +114,8 @@ jobs:
     name: Release
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Set Env
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56-cb-id/bsc/security/code-scanning/18](https://github.com/roseteromeo56-cb-id/bsc/security/code-scanning/18)

To fix the issue, we will add a `permissions` block to the root of the workflow. This will apply the specified permissions to all jobs in the workflow unless overridden by a job-specific `permissions` block. Since the `build` job does not require write access, we will set `contents: read` as the minimal permission. For the `release` job, which uses the `GITHUB_TOKEN` to create a release, we will explicitly set `contents: write`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
